### PR TITLE
Fixed line above the text in editor mode

### DIFF
--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -321,6 +321,7 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     CGRect rect = _textContentView.frame;
     CGFloat height = [self boundingHeightForWidth:rect.size.width];
     rect.size.height = height+self.font.lineHeight;
+    rect.size.height = round(rect.size.height);
     _textContentView.frame = rect;
     self.contentSize = CGSizeMake(self.frame.size.width, rect.size.height+(self.font.lineHeight*2));
 


### PR DESCRIPTION
If rect.size.height (line 323) is not round for example 320.01 sometimes tiny lines appears above editable text (it disappears after few attempts to select text), with rounded height value problem is not appears.

I found it in Seafile iOS client when trying to edit text.
